### PR TITLE
Fix maybeSaveToFile error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -789,6 +789,7 @@ func maybeSaveToFile(filename string, pc string, data string) {
 	f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	defer f.Close()
 


### PR DESCRIPTION
## Summary
- exit early when `os.OpenFile` fails in `maybeSaveToFile`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f7b9ff94c83249edfeaf75c574d59