### PR TITLE
Improve file handling in readRangeFromFile

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,10 @@ func main() {
 							// Get the list of Names from the file
 							fileOfCompNames = argRange[0]
 							computerList = readRangeFromFile(fileOfCompNames)
+							if len(computerList) == 0 {
+								fmt.Println("No computer names found in", fileOfCompNames)
+								os.Exit(12)
+							}
 						} else {
 							// This is NOT a filename so extract the single machine name.
 							argPrefix, argStart, argPad = splitMachineName(argRange[0])
@@ -656,6 +660,7 @@ func readRangeFromFile(myFile string) []string {
 	file, err := os.Open(myFile)
 	if err != nil {
 		fmt.Println(err)
+		return []string{}
 	}
 	defer file.Close()
 	scanner := bufio.NewScanner(file)


### PR DESCRIPTION
## Summary
- exit if no computer names can be loaded from a filename
- stop processing readRangeFromFile if `os.Open` fails

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f7bab908c832489c2088dfe011976