### PR TITLE
Fix debug logging in Bitlocker check

### DIFF
--- a/main.go
+++ b/main.go
@@ -753,7 +753,11 @@ func checkBitlocker(wg *sync.WaitGroup, mu *sync.Mutex, pc string, argShowGood b
 	out, err := exec.Command("powershell", "-Command", psCommand).Output()
 
 	if argDebug {
-		maybeSaveToFile("debug.log", pc, err.Error())
+		if err != nil {
+			maybeSaveToFile("debug.log", pc, err.Error())
+		} else {
+			maybeSaveToFile("debug.log", pc, string(out))
+		}
 	}
 
 	if (err != nil) || (len(string(out)) < 55) {


### PR DESCRIPTION
## Summary
- log command output in debug mode when Bitlocker check succeeds
- only log error message when a Bitlocker call fails

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f7bb30aa08324801f1e2ee8832ab4