### PR TITLE
Add argument validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,10 @@ func main() {
 				// Let's see what it is and set values appropriately
 
 				if v3[0] == "--range" || v3[0] == "-n" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --range requires a value")
+						os.Exit(12)
+					}
 					// split on "-" into start and end args
 					argRange := strings.Split(v3[1], "..")
 					switch len(argRange) {
@@ -109,6 +113,10 @@ func main() {
 				}
 
 				if v3[0] == "--start" || v3[0] == "-s" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --start requires a value")
+						os.Exit(12)
+					}
 					argStart, _ = strconv.Atoi(v3[1])
 				}
 
@@ -117,6 +125,10 @@ func main() {
 				}
 
 				if v3[0] == "--end" || v3[0] == "-e" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --end requires a value")
+						os.Exit(12)
+					}
 					argEnd, _ = strconv.Atoi(v3[1])
 				}
 
@@ -125,10 +137,18 @@ func main() {
 				}
 
 				if v3[0] == "--prefix" || v3[0] == "-x" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --prefix requires a value")
+						os.Exit(12)
+					}
 					argPrefix = v3[1]
 				}
 
 				if v3[0] == "--show" || v3[0] == "-w" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --show requires a value")
+						os.Exit(12)
+					}
 					argShow = v3[1]
 				}
 
@@ -141,10 +161,18 @@ func main() {
 				}
 
 				if v3[0] == "--delay" || v3[0] == "-d" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --delay requires a value")
+						os.Exit(12)
+					}
 					argDelay, _ = strconv.Atoi(v3[1])
 				}
 
 				if v3[0] == "--pad" || v3[0] == "-p" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --pad requires a value")
+						os.Exit(12)
+					}
 					argPad = v3[1]
 				}
 
@@ -181,6 +209,10 @@ func main() {
 				}
 
 				if v3[0] == "--save" || v3[0] == "-v" {
+					if len(v3) <= 1 {
+						fmt.Println("Usage error: --save requires a value")
+						os.Exit(12)
+					}
 					argSave = v3[1]
 				}
 


### PR DESCRIPTION
## Summary
- prevent index errors when parsing command line flags
- exit with usage error when value is missing

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f7bd696bc8324bd8978de4624f837